### PR TITLE
Remove phase from RFB_Net_mobile constructor (#15)

### DIFF
--- a/models/RFB_Net_mobile.py
+++ b/models/RFB_Net_mobile.py
@@ -137,9 +137,8 @@ class BasicRFB_a(nn.Module):
 
 class RFBNet(nn.Module):
 
-    def __init__(self, phase, size, base, extras, head, num_classes):
+    def __init__(self, size, base, extras, head, num_classes):
         super(RFBNet, self).__init__()
-        self.phase = phase
         self.num_classes = num_classes
         self.size = size
 


### PR DESCRIPTION
In case it helps, this is what allowed me to start training with the RFB_mobilenet option (problem explained in #15 ).
